### PR TITLE
Changed uiConfId prop to be optional

### DIFF
--- a/src/components/app/expressRecorder.tsx
+++ b/src/components/app/expressRecorder.tsx
@@ -223,7 +223,9 @@ export class ExpressRecorder extends Component<ExpressRecorderProps, State> {
             tag.type = "text/javascript";
             document.body.appendChild(tag);
         } else if (typeof KalturaPlayer === "undefined") {
-            this.handleError("Kaltura Player was not found in global scope");
+            this.handleError(
+                "Kaltura Player was not found in global scope and uiConfId prop was not provided"
+            );
         }
 
         window.addEventListener("keydown", this.handleKeyboardControl);


### PR DESCRIPTION
### PR Info
- [x] Please functional test this PR
- [x] Already tested in KMS and stand alone

#### Main changes
* If `uiConfId` property is not provided, we will not load the player but will look for it on global scope.
The code execution is changed only for the scenario above, and instead of displaying `Missing props: uiConfId;` error, it will now display `Kaltura Player was not found in global scope`.
* `playerUrl` property is made required only in case `uiConfId` was provided.

#### Known effected areas

#### Special considerations



