### PR TITLE
SUP-47054 - dynamically add height auto

### DIFF
--- a/src/components/App/ExpressRecorder.tsx
+++ b/src/components/App/ExpressRecorder.tsx
@@ -828,7 +828,10 @@ export class ExpressRecorder extends Component<ExpressRecorderProps, State> {
             );
         }
         return (
-            <div className={`express-recorder ${styles["express-recorder"]}`}>
+            <div
+                className={`express-recorder ${styles["express-recorder"]}`}
+                style={{ height: `${constraints.video && !shareScreenOn ? "auto" : "100%"}` }}
+            >
                 {processing ? (
                     <div
                         className={`express-recorder__processing ${styles["express-recorder__processing"]}`}

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -7,7 +7,6 @@
         max-width: 100%;
         max-height: 100%;
         display: block;
-        height: auto;
         width: auto;
     }
     border-radius: 4px;


### PR DESCRIPTION
Problem: height was set to auto for the container and it was messing a lot of styling
Solution: only add auto when only camera is on so the grey borders do not appear

### PR Info
- [x] Please functional test this PR
- [ ] Already tested in KMS and stand alone

#### Main changes
#### Known effected areas
#### Special considerations


